### PR TITLE
Fix Firefox input area overlap issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,6 +59,7 @@ textarea {
 	word-wrap: break-word;
 	word-break: break-all;
 	hyphens: none;
+	-moz-box-sizing: border-box;
 }
 #scroll {
 	position: absolute;


### PR DESCRIPTION
Firefox (apparently) renders `display: table-row` a little differently than other browsers. Since `#scroll-w` had `height: 100%` and `#scroll-h` had `height: 100%` with `padding: 5px`, then the total height of `#scroll-h` ended up being "100% of #scroll-w's height plus 10 pixels". Applying `-moz-box-sizing: border-box` to #scroll-h causes firefox to calculate the height of `#scroll-h` to be 100% of `#scroll-w`'s height, no matter what extra padding (or borders) are added. Note that applying this same style to chrome/safari (with `box-sizing: border-box`) breaks `#scroll-h`'s height and causes it to be too short.
