### PR TITLE
cache tojs() results for palette values

### DIFF
--- a/ike/ike.html
+++ b/ike/ike.html
@@ -480,7 +480,9 @@ function paintEach(g, v) {
 	else { return; }
 	// palette:
 	var pal = getvar(v[1]); if (pal.t != 3) { return; }
-	var colors = tojs(pal);
+	if (pal._tojs_cached === undefined)
+		pal._tojs_cached = tojs(pal);
+	var colors = pal._tojs_cached;
 	// sprite:
 	var img = getvar(v[2]);
 	if (img.t == 0) {


### PR DESCRIPTION
This makes ike.html?gist=387b349f31969a409d65 render 2x faster.
The per-frame time goes from 240ms to 100ms.

This may not be the best placement for the caching, but when drawing 14000 pixels, tojs is the bottlneck.
