### PR TITLE
Add support for running rc file on REPL startup

### DIFF
--- a/repl.js
+++ b/repl.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 var ok = require('./oK');
 var fs = require('fs');
+var os = require('os');
 var path = require('path');
 var readline = require('readline');
 var conv = require('./convert');
@@ -44,6 +45,15 @@ for (var i = 0; i < 2; i++) { ok.setIO('0:', i, read ); }
 for (var i = 2; i < 6; i++) { ok.setIO('0:', i, write); }
 
 var env = ok.baseEnv();
+
+// run user prelude file if exists
+try {
+	var preludeFile = os.homedir() + "/.config/okrc.k"
+	var program = fs.readFileSync(preludeFile, 'utf8');
+	ok.run(ok.parse(program), env)
+} catch (err) {
+	if (err.code != 'ENOENT') throw err
+}
 
 // process filename.k as a command-line arg
 if (process.argv.length > 2) {


### PR DESCRIPTION
Runs ~/.config/okrc.k on startup of repl.js if it exists (otherwise it is ignored). This was prompted by me recently experimenting with K5 using oK, and then wanting to save some utility functions for re-use later. I could put them in a file and just copy-paste as necessary, but it would be even nicer if I could put them in a file that gets sourced automatically on REPL startup.

The reliance on exception handling to see if the file exists is a bit.. crude and ugly to me, but it seems to be the recommended approach: https://nodejs.org/api/fs.html#fs_fs_exists_path_callback
