### PR TITLE
Inhibit canvas click default behavior of selecting elements.

### DIFF
--- a/ike/ike.html
+++ b/ike/ike.html
@@ -752,10 +752,12 @@ window.onkeypress = function(e) {
 canvas.onmousedown = function(e) {
 	click = true;
 	if(running) { callk2("md", Math.floor(e.offsetX/SCALE), Math.floor(e.offsetY/SCALE)); }
+	e.preventDefault();
 }
 canvas.onmouseup = function(e) {
 	click = false;
 	if(running) { callk2("mu", Math.floor(e.offsetX/SCALE), Math.floor(e.offsetY/SCALE)); }
+	e.preventDefault();
 }
 canvas.onmousemove = function(e) {
 	if(!running) { return; }
@@ -764,6 +766,7 @@ canvas.onmousemove = function(e) {
 	callk2("mm", mx, my);
 	if (!click) { return; }
 	callk2("mg", mx, my);
+	e.preventDefault();
 }
 var fullcanvas = document.getElementById("fullcanvas");
 fullcanvas.onmousedown = canvas.onmousedown;


### PR DESCRIPTION
This makes double-clicking [here](http://rmmh.github.io/ok/ike/ike.html?gist=cb8c67ad9ba58513e9ba1f8794b6a968) not select the X at the top right.
