### PR TITLE
Add a package.json for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{ "name": "ok"
+, "version": "0.0.0"
+, "license" : "MIT"
+, "description": "An open-source interpreter for the K5 programming language"
+, "scripts": { "start": "node repl.js" }
+, "main": "oK.js"
+}


### PR DESCRIPTION
This allows the usage of oK as a library with dependencies linked via npm. I'm currently using it as one, so it's useful to have this upstream.

It also allows eventual publishing on the npm package repository.
