### PR TITLE
ike playground: add link to documentation

### DIFF
--- a/ike/ike.html
+++ b/ike/ike.html
@@ -97,6 +97,11 @@ canvas.full {
 	left: 50%;
 	margin: -240px 0 0 -240px;
 }
+#docs {
+	position: absolute;
+	bottom: 12px;
+	right: 665px;
+}
 #examples {
 	position: absolute;
 	bottom: 10px;
@@ -131,6 +136,7 @@ button:focus {
 			<img src="img/full.png" title="Fullscreen" onclick="fullscreen();"></img>
 		</div>
 		<canvas width="320" height="320" id="canvas"></canvas>
+		<a href="https://github.com/JohnEarnest/ok.git" id="docs">Documentation</a>
 		<select id="examples">
 			<option>Choose an Example...</option>
 		</select>


### PR DESCRIPTION
located on the bottom left, like so: 
![image](https://github.com/JohnEarnest/ok/assets/11015319/b0c6f9bc-cf3e-4dd9-8a0a-0ae00e0a9116)
